### PR TITLE
Set the current module so that Intersphinx links work.

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,6 +2,7 @@
 fibers: lightweight concurrent multitasking
 ===========================================
 
+.. module:: fibers
 
 Overview
 --------


### PR DESCRIPTION
Without the ..module:: directive, it's not possible to refer to python-fibers via Intersphinx links as :class:`fibers.Fiber`
