### PR TITLE
replaced unused `_is_started` attribute with `_ended`

### DIFF
--- a/fibers/_pyfibers.py
+++ b/fibers/_pyfibers.py
@@ -116,7 +116,7 @@ class Fiber(object):
 def _create_main_fiber():
     main_fiber = Fiber.__new__(Fiber)
     main_fiber._cont = _continuation.continulet.__new__(_continuation.continulet)
-    main_fiber._is_started = True
+    main_fiber._ended = False
     main_fiber._thread_id = threading.current_thread().ident
     main_fiber.__dict__['parent'] = None
     return main_fiber


### PR DESCRIPTION
In _pyfibers.py, I found an attribute `_is_started`, which is never used. If I understand it correctly, It should be `_ended` though this bug does not seem to cause any trouble in most cases.
