### PR TITLE
drop Python 3.3, 3.4 and 2.7 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
   - "pypy3"
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
 sudo: false
 python:
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
-  # pypy2.7-5.8.0 is broken in Travis
   - "3.6"
   - "pypy-5.6.0"
   - "pypy3.5-5.8.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: python
 sudo: false
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy-5.6.0"
-  - "pypy3.5-5.8.0"
+  - "pypy3"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: false
 python:
   - "3.5"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - "3.5"
   - "3.6"
-  - "3.7"
-  - "3.8"
+  # - "3.7"
+  # - "3.8"
   - "pypy3"
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,30 +6,6 @@ environment:
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3.x"
-      PYTHON_ARCH: "64"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "32"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4.x"
-      PYTHON_ARCH: "64"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5.x"
       PYTHON_ARCH: "32"
@@ -71,7 +47,7 @@ install:
   - "python -c \"import struct; print(struct.calcsize('P') * 8)\""
 
   # Upgrade to the latest version of pip
-  - "pip install --disable-pip-version-check --user --upgrade pip"
+  - "python -m pip install --disable-pip-version-check --user --upgrade pip"
 
   # Install wheel
   - "%CMD_IN_ENV% pip install wheel"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,22 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python38"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8.x"
+      PYTHON_ARCH: "64"
+
 branches:
   only:
     - master

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,21 +22,21 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python37"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "32"
+    #- PYTHON: "C:\\Python37"
+    #  PYTHON_VERSION: "3.7.x"
+    #  PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python37-x64"
-      PYTHON_VERSION: "3.7.x"
-      PYTHON_ARCH: "64"
+    #- PYTHON: "C:\\Python37-x64"
+    #  PYTHON_VERSION: "3.7.x"
+    #  PYTHON_ARCH: "64"
 
-    - PYTHON: "C:\\Python38"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "32"
+    #- PYTHON: "C:\\Python38"
+    #  PYTHON_VERSION: "3.8.x"
+    #  PYTHON_ARCH: "32"
 
-    - PYTHON: "C:\\Python38-x64"
-      PYTHON_VERSION: "3.8.x"
-      PYTHON_ARCH: "64"
+    #- PYTHON: "C:\\Python38-x64"
+    #  PYTHON_VERSION: "3.8.x"
+    #  PYTHON_ARCH: "64"
 
 branches:
   only:


### PR DESCRIPTION
From testing, drop old Python versions 3.3 and 2.7.