### PR TITLE
docs: Fix a few typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ Example:
     f1.switch()
 
 
-The avove example will print "1 2 3 4", but the result was obtained by the
+The above example will print "1 2 3 4", but the result was obtained by the
 cooperative work of 2 fibers yielding control to each other.
 
 

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -6,7 +6,7 @@ Why fibers
 
 Fibers was created because I wanted to implement an API which looked pretty much
 like a thread but with greenlet, but the API offered by greenlet got in the way,
-so I decided to try and extract the minimum ammount of funcionality I needed and
+so I decided to try and extract the minimum amount of functionality I needed and
 make the API *I* wanted to use.
 
 Note the use of the first person singular here, this was created for myself, I'm

--- a/src/switch_arm_gcc.h
+++ b/src/switch_arm_gcc.h
@@ -31,7 +31,7 @@ static void *slp_switch(void *(*save_state)(void*, void*),
     /* We also push d8-d15 to preserve them explicitly.  This assumes
      * that this code is in a function that doesn't use floating-point
      * at all, and so don't touch the "d" registers (that's why we mark
-     * it as non-inlinable).  So here by pushing/poping d8-d15 we are
+     * it as non-inlinable).  So here by pushing/popping d8-d15 we are
      * saving precisely the callee-saved registers in all cases.  We
      * could also try to list all "d" registers as clobbered, but it
      * doesn't work: there is no way I could find to know if we have 16

--- a/src/switch_ppc64_gcc.h
+++ b/src/switch_ppc64_gcc.h
@@ -184,7 +184,7 @@ void *slp_switch(void *(*save_state)(void*, void*),
      "li 12,-304\n"
      "lvx 31,12,1\n"
 
-     "ld  14,-288(1)\n"     /* restore general purporse registers */
+     "ld  14,-288(1)\n"     /* restore general purpose registers */
      "ld  15,-280(1)\n"
      "ld  16,-272(1)\n"
      "ld  17,-264(1)\n"

--- a/tests/test_fibers.py
+++ b/tests/test_fibers.py
@@ -32,7 +32,7 @@ def fmain(seen):
 
 def send_exception(g, exc):
     # note: send_exception(g, exc)  can be now done with  g.throw(exc).
-    # the purpose of this test is to explicitely check the propagation rules.
+    # the purpose of this test is to explicitly check the propagation rules.
     def crasher(exc):
         raise exc
     g1 = Fiber(target=crasher, args=(exc, ), parent=g)


### PR DESCRIPTION
There are small typos in:
- README.rst
- docs/why.rst
- src/switch_arm_gcc.h
- src/switch_ppc64_gcc.h
- tests/test_fibers.py

Fixes:
- Should read `purpose` rather than `purporse`.
- Should read `popping` rather than `poping`.
- Should read `functionality` rather than `funcionality`.
- Should read `amount` rather than `ammount`.
- Should read `explicitly` rather than `explicitely`.
- Should read `above` rather than `avove`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md