### PR TITLE
Restore compatibility with Python 3.11

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
         # would use windows-latest, but distutils tries to build against the version of MSVC that python was compiled with
         #   https://github.com/pypa/setuptools/blob/main/setuptools/_distutils/msvc9compiler.py#L403
         os: [ "ubuntu-latest", "macos-12", "windows-2019" ]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         #os: [ "ubuntu-latest" ]
         #python-version: ["3.8"]
 

--- a/src/fibers.h
+++ b/src/fibers.h
@@ -30,6 +30,12 @@ typedef struct _fiber {
     PyObject *args;
     PyObject *kwargs;
     struct {
+#if PY_MINOR_VERSION >= 11
+        _PyCFrame *cframe;
+        _PyStackChunk *datastack_chunk;
+        PyObject **datastack_top;
+        PyObject **datastack_limit;
+#endif
         struct _frame *frame;
         int recursion_depth;
         _PyErr_StackItem exc_state;

--- a/tests/test_fibers.py
+++ b/tests/test_fibers.py
@@ -6,6 +6,7 @@ import unittest
 
 import os
 import sys
+import traceback
 
 import fibers
 from fibers import Fiber, current
@@ -68,6 +69,19 @@ class FiberTests(unittest.TestCase):
         g.switch()
         lst.append(4)
         assert lst == list(range(5))
+
+    def test_clean_callstack(self):
+        lst = []
+        
+        def f():
+            for line in traceback.format_stack():
+                lst.append(line)
+        f()
+        expected = [lst[-1]]
+        lst = []
+        g = Fiber(f)
+        g.switch()
+        assert lst == expected
 
     def test_two_children(self):
         lst = []


### PR DESCRIPTION
* PyFrameObjects are now lazily allocated and no longer part of the PyThreadState. Therefore switch the _PyCFrame instead, but keep the PyFrameObject* for GC.

  https://github.com/python/cpython/commit/ae0a2b756255629140efcbe57fc2e714f0267aa3

* The recursion_depth is no longer stored directly in the PyThreadState and needs to be calculated from recursion_remaining and recursion_limit.

  https://github.com/python/cpython/commit/b9310773756f40f77e075f221a90dd41e6964efc

* The exc_state was also simplified (no more exc_type and exc_traceback).

  https://github.com/python/cpython/commit/396b58345f81d4c8c5a52546d2288e666a1b9b8b

* Finally the frame "data stack" needs to be saved and restored. How this was done in python-greenlet was used as a reference.

  https://github.com/python-greenlet/greenlet/pull/280

* Add new test test_clean_callstack to check that the call stack from the creation of the Fiber doesn't leak into it (i.e. `tstate->cframe->current_frame = NULL;` in `stacklet__callback`; `tstate->frame = NULL;` in older Python versions).